### PR TITLE
updated to change -cpu from host to max

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -57,14 +57,15 @@ create_machine(){
   podman system connection default $NAME
 
   # alter qemu configuration to set type as x86 and remove unsupported parameters
+  # changed '-cpu host' to '-cpu max' to resolve 'Fatal glibc error: CPU does not support x86-64-v2' for RHEL 9 images
   mylog info "Fixing machine $NAME parameters"
   config_file=$(podman machine inspect $NAME|jq -r '.[0].ConfigPath.Path')
   sed -E \
     -e '/^  "-[^"]*",$/ N' \
     -e 's|aarch64|x86_64|' \
+    -e 's|host|max|' \
     -e '/ovmf_vars/ d' \
     -e '/"-accel",/ d' \
-    -e '/"-cpu",/ d' \
     -e '/"-M",/ d' \
     -i '' \
     "$config_file"


### PR DESCRIPTION
Hi - your scripts have really helped with simplifying getting Podman x86_64 machine running on M1 MAC. I hit and issue when using RHEL 9 image. 

Error msg: Fatal glibc error: CPU does not support x86-64-v2

Further details [here](https://access.redhat.com/solutions/6833751)

I have updated configure.sh to change the -cpu from host to max

To test:

download RHEL 9 image

```shell
podman pull registry.access.redhat.com/ubi9/ubi-minimal:latest
```
then

```shell
podman run registry.access.redhat.com/ubi9/ubi-minimal echo "Red Hat"
```

Without the change you will see the Fatal glibc error: CPU does not support x86-64-v2 error.

Thanks Adrian 




